### PR TITLE
fixing "undefined method 'opacity'" bug

### DIFF
--- a/pong.rb
+++ b/pong.rb
@@ -115,7 +115,7 @@ end
 on :key_down do |event|
   if event.key == 'space'
     match.paused = !match.paused
-    pause_display.opacity *= -1
+    pause_display.color.opacity *= -1
   end
 end
 


### PR DESCRIPTION
The game crashes when run with ruby2d-0.11.3. It seems like the Text object doesn't have the 'opacity' attribute anymore.